### PR TITLE
fix: nested folding ranges overlap issue

### DIFF
--- a/src/providers/bracketRangesProvider.ts
+++ b/src/providers/bracketRangesProvider.ts
@@ -101,8 +101,8 @@ export class BracketRangesProvider extends BetterFoldingRangeProvider {
 
     const endLineContent = document.lineAt(bracketsRange.end.line).text;
     const afterClosing = endLineContent.slice(bracketsRange.end.character);
-
-    if (afterClosing.trim().length > 0) {
+    const endChar = afterClosing.charAt(afterClosing.length - 1)
+    if (endChar === '{' || endChar === '[' || endChar === '(') {
       end = Math.max(start, end - 1);
     }
 
@@ -256,12 +256,9 @@ export class BracketRangesProvider extends BetterFoldingRangeProvider {
     const lineContent = document.lineAt(line).text;
 
     const afterClosing = lineContent.slice(bracketsRange.end.character);
-    if (afterClosing.trim().length > 0) {
+    const endChar = afterClosing.charAt(afterClosing.length - 1)
+    if (endChar === '{' || endChar === '[' || endChar === '(') {
       return [end, collapsedText.slice(0, -1)];
-    }
-
-    if (!chainFoldingRanges) {
-      collapsedText = initialCollapsedText.slice(0, -1);
     }
 
     for (let column = bracketsRange.end.character; column < lineContent.length; column++) {

--- a/src/providers/bracketRangesProvider.ts
+++ b/src/providers/bracketRangesProvider.ts
@@ -99,6 +99,13 @@ export class BracketRangesProvider extends BetterFoldingRangeProvider {
       [end, collapsedText] = this.appendPostFoldingRangeText(bracketsRange, collapsedText, document);
     }
 
+    const endLineContent = document.lineAt(bracketsRange.end.line).text;
+    const afterClosing = endLineContent.slice(bracketsRange.end.character);
+
+    if (afterClosing.trim().length > 0) {
+      end = Math.max(start, end - 1);
+    }
+
     return { start, end, startColumn, collapsedText };
   }
 
@@ -247,6 +254,15 @@ export class BracketRangesProvider extends BetterFoldingRangeProvider {
 
     const line = bracketsRange.end.line;
     const lineContent = document.lineAt(line).text;
+
+    const afterClosing = lineContent.slice(bracketsRange.end.character);
+    if (afterClosing.trim().length > 0) {
+      return [end, collapsedText.slice(0, -1)];
+    }
+
+    if (!chainFoldingRanges) {
+      collapsedText = initialCollapsedText.slice(0, -1);
+    }
 
     for (let column = bracketsRange.end.character; column < lineContent.length; column++) {
       const foldingRange = this.positionToFoldingRange.get([line, column]);


### PR DESCRIPTION
Fixed an issue where nested code blocks (if/else, functions, etc.) were not showing fold icons due to range overlap

Block chaining corruption - When folding else if blocks, subsequent code blocks were incorrectly merged into the collapsed text, breaking code structure

Before fix:
<img width="829" height="79" alt="image" src="https://github.com/user-attachments/assets/b231312a-c031-4eb1-8cb9-5a39736ff94b" />

After fix:
<img width="475" height="92" alt="image" src="https://github.com/user-attachments/assets/be375511-e6f0-4284-9928-a879789b1a4e" />
